### PR TITLE
fix: stop sending voting dm if user has already voted

### DIFF
--- a/src/main/kotlin/me/ddivad/suggestions/Main.kt
+++ b/src/main/kotlin/me/ddivad/suggestions/Main.kt
@@ -54,7 +54,7 @@ suspend fun main() {
             field {
                 name = "Build Info"
                 value = "```" +
-                        "Version:   1.2.0\n" +
+                        "Version:   1.2.1\n" +
                         "DiscordKt: ${versions.library}\n" +
                         "Kotlin:    $kotlinVersion\n" +
                         "Kord:      ${versions.kord}\n" +

--- a/src/main/kotlin/me/ddivad/suggestions/listeners/VotingListeners.kt
+++ b/src/main/kotlin/me/ddivad/suggestions/listeners/VotingListeners.kt
@@ -23,6 +23,7 @@ fun onVotingReactionAdded(configuration: Configuration, suggestionService: Sugge
                 if (guildConfiguration.removeVoteReactions) {
                     message.deleteReaction(userId, emoji)
                 }
+                if (user.id in suggestion.upvotes) return@on
                 with(suggestionService) {
                     recordUpvote(guild, user.asUser(), messageId)
                     updateStatus(guild, suggestion, suggestion.status)
@@ -36,6 +37,7 @@ fun onVotingReactionAdded(configuration: Configuration, suggestionService: Sugge
                 if (guildConfiguration.removeVoteReactions) {
                     message.deleteReaction(userId, emoji)
                 }
+                if (user.id in suggestion.downvotes) return@on
                 with(suggestionService) {
                     recordDownvote(guild, user.asUser(), messageId)
                     updateStatus(guild, suggestion, suggestion.status)


### PR DESCRIPTION
# fix: stop sending voting dm if user has already voted

Add a check to see if a user has upvoted / downvoted already, and return from the listener if they have. It didn't count these extra votes, but always sent a DM even if the user had voted for the same option already.